### PR TITLE
add senders into rooms user presenter

### DIFF
--- a/app/controllers/user/rooms_controller.rb
+++ b/app/controllers/user/rooms_controller.rb
@@ -4,7 +4,7 @@ class User::RoomsController < UserController
     only_closed       = params[:only_closed] == "true"
     room_ids          = params[:room_ids]
     rooms_per_page    = params[:per_page].try(:to_i) || Room::PER_PAGE
-    rooms             = current_user.rooms.includes(:users)
+    rooms             = current_user.rooms.includes(:users, :senders)
 
     if params[:first_seen_room_id]
       first_seen_room = current_user.rooms.find_by!(public_id: params[:first_seen_room_id])

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -36,6 +36,7 @@ class Room < ActiveRecord::Base
   has_many   :messages, dependent: :destroy
   has_many   :memberships, dependent: :destroy
   has_many   :users, through: :memberships
+  has_many   :senders, -> { uniq }, through: :messages
   belongs_to :initiator, class_name: "User"
   belongs_to :platform
 

--- a/app/presenters/user/room_presenter.rb
+++ b/app/presenters/user/room_presenter.rb
@@ -34,7 +34,8 @@ class User::RoomPresenter < BasePresenter
           messages:       @room.messages_before(@messages_per_room, @first_seen_message),
           room_public_id: @room.public_id
         ),
-        users:    User::UserPresenter.map(@room.users)
+        users:    User::UserPresenter.map(@room.users),
+        senders:  User::UserPresenter.map(@room.senders)
       }
     }
     result[:relationships][:initiator] =  User::UserPresenter.new(@room.initiator).data if @room.initiator


### PR DESCRIPTION
add senders of rooms on user API. This allows the client to load all users that sent a message even if these users no longer belongs to the room.